### PR TITLE
Enabling travis-CI by adding .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 #  - rm database/CLAS12OCR_DB.db
   - python2 server/src/new_db.py
   - cd client
-#  - python2 src/SubMit.py
+  - python2 src/SubMit.py
   - cd ../server/src
   - python2 Submit_batch.py
 #to submit to HTCondor on Submit, for example, do the following:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+# command to run tests
+script:
+#To run this from scratch, now do the following:
+  - cd clas12simulations
+#if a database file exists, remove it with
+  - rm database/CLAS12OCR_DB.db
+  - python2 server/src/new_db.py
+  - cd client
+  - python2 src/SubMit.py
+  - cd ../server/src
+  - python2 Submit_batch.py
+#to submit to HTCondor on Submit, for example, do the following:
+#python2 Submit_batch.py -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 python:
-  - "2.6"
+#  - "2.6"
   - "2.7"
 # command to run tests
 script:
 #To run this from scratch, now do the following:
-  - cd clas12simulations
+# cd clas12simulations
 #if a database file exists, remove it with
-  - rm database/CLAS12OCR_DB.db
+#  - rm database/CLAS12OCR_DB.db
   - python2 server/src/new_db.py
   - cd client
-  - python2 src/SubMit.py
+#  - python2 src/SubMit.py
   - cd ../server/src
   - python2 Submit_batch.py
 #to submit to HTCondor on Submit, for example, do the following:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+#  - "2.6"
+  - "2.7"
+# command to run tests
+script:
+#To run this from scratch, now do the following:
+#cd clas12simulations
+#if a database file exists, remove it with
+#  - rm database/CLAS12OCR_DB.db
+  - python2 server/src/new_db.py
+  - cd client
+  - python2 src/SubMit.py
+  - cd ../server/src
+  - python2 Submit_batch.py
+#to submit to HTCondor on Submit, for example, do the following:
+#python2 Submit_batch.py -s
+addons:
+  hosts:
+    - travis.dev
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - python2 src/SubMit.py
   - cd ../server/src
   - python2 Submit_batch.py
+  - cat database/CLAS12_OCRDB.db 
 #to submit to HTCondor on Submit, for example, do the following:
 #python2 Submit_batch.py -s
 addons:

--- a/client/src/utils/user_validation.py
+++ b/client/src/utils/user_validation.py
@@ -10,13 +10,20 @@ import sqlite3, time
 import utils, file_struct, argparse, socket, subprocess
 import datetime
 from subprocess import PIPE, Popen
+import os
 
 def user_validation():
   #These next two lines are good but do not work on python < 2.7
   #username = (subprocess.check_output('whoami'))[:-1]#The [:-1] is so we drop the implicit \n from the string
   #domain_name = subprocess.check_output(['hostname','-d'])#socket.getfqdn()  #socket.getdomain_name()
   username = Popen(['whoami'], stdout=PIPE).communicate()[0].split()[0]
-  domain_name = Popen(['hostname','-d'], stdout=PIPE).communicate()[0].split()[0]
+  is_travis = 'TRAVIS' in os.environ
+  if is_travis == True:
+	print("We're at travis-ci environment")
+	fake_domain = "travis.dev"
+	domain_name = fake_domain
+  else:
+  	domain_name = Popen(['hostname','-d'], stdout=PIPE).communicate()[0].split()[0]
   strn = """SELECT 1 FROM Users WHERE EXISTS (SELECT 1 FROM Users WHERE User ="{0}"
           AND domain_name = "{1}")""".format(username,domain_name)
   user_already_exists = utils.sql3_grab(strn)


### PR DESCRIPTION
Now, you can go to https://travis-ci.org/,
sign-in (sign up via github if you didn't), and sanity-check via travis.

One change was made at user_validation.py for these reasons.
- hostname is not correctly working at travis, so I had to add one condition to detect travis.
- If travis detected, assign hostname as a fake one, "travis.dev"
